### PR TITLE
Version up to v1.12.0-release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 subprojects {
     group "com.gaia3d"
-    version "1.11.7"
+    version "1.12.0-release"
     apply plugin: 'java'
     project.ext.lwjglVersion = "3.3.3"
 

--- a/tiler/src/main/java/com/gaia3d/process/preprocess/GaiaTranslation.java
+++ b/tiler/src/main/java/com/gaia3d/process/preprocess/GaiaTranslation.java
@@ -45,17 +45,22 @@ public class GaiaTranslation implements PreProcess {
         }
 
         // set position terrain height
-        coverages.forEach((coverage) -> {
-            DirectPosition worldPosition = new DirectPosition2D(DefaultGeographicCRS.WGS84, center.x, center.y);
-            double[] altitude = new double[1];
-            altitude[0] = 0;
-            try {
-                coverage.evaluate(worldPosition, altitude);
-            } catch (Exception e) {
-                log.debug("[DEBUG] Failed to load terrain height. Out of range");
-            }
-            center.z = altitude[0];
-        });
+        if (!coverages.isEmpty()) {
+            center.z = 0.0d;
+            coverages.forEach((coverage) -> {
+                DirectPosition worldPosition = new DirectPosition2D(DefaultGeographicCRS.WGS84, center.x, center.y);
+                double[] altitude = new double[1];
+                altitude[0] = 0.0d;
+                try {
+                    coverage.evaluate(worldPosition, altitude);
+                } catch (Exception e) {
+                    log.debug("[DEBUG] Failed to load terrain height. Out of range");
+                }
+                if (altitude[0] != 0.0d && !Double.isNaN(altitude[0])) {
+                    center.z = altitude[0];
+                }
+            });
+        }
 
         KmlInfo kmlInfo = getKmlInfo(tileInfo, center);
         Matrix4d translationMatrix = new Matrix4d().translate(translation);

--- a/tiler/src/test/java/com/gaia3d/release/small/B3dmReleaseTest.java
+++ b/tiler/src/test/java/com/gaia3d/release/small/B3dmReleaseTest.java
@@ -91,7 +91,8 @@ class B3dmReleaseTest {
         String[] args = new String[] {
                 "-i", getInputPath(path).getAbsolutePath(),
                 "-o", getOutputPath(path).getAbsolutePath(),
-                "-terrain", getInputPath(path).getAbsolutePath() + "/seoul.tif",
+                //"-terrain", getInputPath(path).getAbsolutePath() + "/seoul.tif",
+                "-terrain", "G:\\(archive)\\(archive) 3차원 데이터 모음\\GeoTIFF\\korea_5m\\5m\\37608(서울)",
                 "-c", "5186"
         };
         execute(args);


### PR DESCRIPTION
![images4-mini](https://github.com/user-attachments/assets/c070b8b5-dfcf-42b9-b910-9f701333687f)

# mago-3d-tiler v1.12.0-release

This release includes major feature additions and fixes, notably support for `Photogrammetry` conversion and the `GeoPackage` format.  We've also added support for point cloud `intensity/classification` properties, the ability to generate i3dm from polygons, and more.

_As a side note, I'm working on automating release note generation from PRs, since writing them manually is quite tedious._
  
## [Feature Additions]

### GeoPackage format support.
- Converts geometry-only GeoJSON and SHP files into extrusion/pipe/i3dm tiles.

### i3dm: Automatically Create Point Instances from Vector Polygons
- Conversion can be controlled using density and scale values.
- Useful for tree datasets (e.g., clinical chart data).
- New CLI options:
  - `--densityColumn "density_value"`
  - `--scaleColumn "scale_value"`

### Add Photogrammetry Tiling feature
Used to process mesh data generated by photogrammetry method.
Generated by b3dm but can be executed by adding ```--photogrammetry``` option.
- Split and rearrange large 3D model data
- Automatically generate models with LODs
* This feature utilizes GPU and may not work properly on devices that do not recognize GPU.

### Point Cloud `Intensity/Classification` Properties Added
- `INTENSITY` and `CLASSIFICATION` properties added to the `.pnts` file BatchTable.
- Example usage in CesiumJS:
```js
  tileset.style = new Cesium.Cesium3DTileStyle({
      color: "rgb(${INTENSITY}, ${INTENSITY}, ${INTENSITY})"
  });
```

### Multi-Geotiff support for terrain data 
You can now specify terrain paths in the form of directories.
You can use both ```--terrain /data/terrain.tif``` and ```--terrain /data/terrains```.
* However, it may have a performance impact.

### Add Tileset merge function
Search for tileset.json files in a subfolder by output path and run
and link them. 

You can do this by passing ```/parent``` as an argument to input and output when you have a directory structure like the one below.
```
/parent/
/parent/child1/tileset.json
/parent/child2/tileset.json
/parent/child3/child1/tileset.json
/parent/child4/child1/tileset.json
...
```

Example usage:
``` cmd
--input <arg> --output <arg> --merge 
```

## [Feature Improvement]
- The JAR File is now unified and no longer split by platform (`Windows`, `Linux`, `macOS`).
- A floor plane has been added to extrusion models, allowing classification with CesiumJS.
- Improved automatic CRS detection when reading GIS vector and LAS data, even if the `-crs` flag is not provided.

## [Bug Fix]
- Fixed a normalization bug in geometry processing.
- Resolved an issue where `z` height values became `NaN` when converting polylines.
- Fixed the `refineAdd` bug so it is now always applied when working with `Vector2D` data.

## [Deprecated]
- The ```--zeroOrigin``` option has been deprecated.