### PR TITLE
3D Tiles generation with cartesic coordinates

### DIFF
--- a/tiler/src/main/java/com/gaia3d/command/mago/GlobalOptions.java
+++ b/tiler/src/main/java/com/gaia3d/command/mago/GlobalOptions.java
@@ -97,6 +97,7 @@ public class GlobalOptions {
     // projection options
     private CoordinateReferenceSystem crs; // default crs
     private String proj; // proj4 string
+    private boolean cartesian = false;
     private Vector3d translateOffset; // origin offset
 
     private boolean isSourcePrecision = false;
@@ -254,6 +255,7 @@ public class GlobalOptions {
             instance.setInstancePath(instancePath);
         }
 
+        instance.setCartesian(command.hasOption(ProcessOptions.CARTESIAN.getLongName()));
         if (command.hasOption(ProcessOptions.PROJ4.getLongName())) {
             instance.setProj(command.hasOption(ProcessOptions.PROJ4.getLongName()) ? command.getOptionValue(ProcessOptions.PROJ4.getLongName()) : null);
             CoordinateReferenceSystem crs = null;

--- a/tiler/src/main/java/com/gaia3d/command/mago/ProcessOptions.java
+++ b/tiler/src/main/java/com/gaia3d/command/mago/ProcessOptions.java
@@ -25,6 +25,7 @@ public enum ProcessOptions {
     // Coordinate Options
     CRS("crs", "c", true,"Coordinate Reference Systems, EPSG Code(4326, 3857, 32652, 5186...)"),
     PROJ4("proj", "p",  true, "Proj4 parameters (ex: +proj=tmerc +la...)"),
+    CARTESIAN("cartesian", "ca", false, "[Experimental] Output in a cartesion CRS (no projection)"),
     X_OFFSET("xOffset", "xo", true, "X Offset value for coordinate transformation"),
     Y_OFFSET("yOffset", "yo", true, "Y Offset value for coordinate transformation"),
     Z_OFFSET("zOffset", "zo", true, "Z Offset value for coordinate transformation"),

--- a/tiler/src/main/java/com/gaia3d/process/preprocess/GaiaTranslation.java
+++ b/tiler/src/main/java/com/gaia3d/process/preprocess/GaiaTranslation.java
@@ -90,7 +90,7 @@ public class GaiaTranslation implements PreProcess {
         GlobalOptions globalOptions = GlobalOptions.getInstance();
         Vector3d position;
         Vector3d offset = globalOptions.getTranslateOffset();
-        if (offset == null) {
+        if (offset == null || globalOptions.isCartesian()) { // For cartesian output, apply offset on root node only
             offset = new Vector3d();
         }
         if (formatType == FormatType.CITYGML || formatType == FormatType.INDOORGML || formatType == FormatType.SHP || formatType == FormatType.GEOJSON || formatType == FormatType.GEO_PACKAGE) {

--- a/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/Batched3DModelTiler.java
+++ b/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/Batched3DModelTiler.java
@@ -45,7 +45,7 @@ public class Batched3DModelTiler extends DefaultTiler implements Tiler {
         }
 
         Node root = createRoot();
-        root.setBoundingVolume(new BoundingVolume(globalBoundingBox, true));
+        root.setBoundingVolume(new BoundingVolume(globalBoundingBox, globalOptions.isCartesian()));
         root.setTransformMatrix(transformMatrix, globalOptions.isClassicTransformMatrix());
         root.setGeometricError(geometricError);
 
@@ -174,7 +174,7 @@ public class Batched3DModelTiler extends DefaultTiler implements Tiler {
         if (globalOptions.isClassicTransformMatrix()) {
             rotateX90(transformMatrix);
         }
-        BoundingVolume boundingVolume = new BoundingVolume(boundingBox, true);
+        BoundingVolume boundingVolume = new BoundingVolume(boundingBox, globalOptions.isCartesian());
         geometricError = DecimalUtils.cutFast(geometricError);
 
         Node childNode = new Node();
@@ -201,7 +201,7 @@ public class Batched3DModelTiler extends DefaultTiler implements Tiler {
         if (globalOptions.isClassicTransformMatrix()) {
             rotateX90(transformMatrix);
         }
-        BoundingVolume boundingVolume = new BoundingVolume(childBoundingBox, true);
+        BoundingVolume boundingVolume = new BoundingVolume(childBoundingBox, globalOptions.isCartesian());
 
         String nodeCode = parentNode.getNodeCode();
         LevelOfDetail minLod = LevelOfDetail.getByLevel(minLevel);
@@ -234,6 +234,7 @@ public class Batched3DModelTiler extends DefaultTiler implements Tiler {
         childNode.setParent(parentNode);
         childNode.setTransformMatrix(transformMatrix, globalOptions.isClassicTransformMatrix());
         childNode.setBoundingVolume(boundingVolume);
+        childNode.setCartesian(globalOptions.isCartesian());
         childNode.setNodeCode(nodeCode);
         childNode.setGeometricError(lodError + 0.1);
         childNode.setChildren(new ArrayList<>());

--- a/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/Batched3DModelTiler.java
+++ b/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/Batched3DModelTiler.java
@@ -45,7 +45,7 @@ public class Batched3DModelTiler extends DefaultTiler implements Tiler {
         }
 
         Node root = createRoot();
-        root.setBoundingVolume(new BoundingVolume(globalBoundingBox));
+        root.setBoundingVolume(new BoundingVolume(globalBoundingBox, true));
         root.setTransformMatrix(transformMatrix, globalOptions.isClassicTransformMatrix());
         root.setGeometricError(geometricError);
 
@@ -174,7 +174,7 @@ public class Batched3DModelTiler extends DefaultTiler implements Tiler {
         if (globalOptions.isClassicTransformMatrix()) {
             rotateX90(transformMatrix);
         }
-        BoundingVolume boundingVolume = new BoundingVolume(boundingBox);
+        BoundingVolume boundingVolume = new BoundingVolume(boundingBox, true);
         geometricError = DecimalUtils.cutFast(geometricError);
 
         Node childNode = new Node();
@@ -201,7 +201,7 @@ public class Batched3DModelTiler extends DefaultTiler implements Tiler {
         if (globalOptions.isClassicTransformMatrix()) {
             rotateX90(transformMatrix);
         }
-        BoundingVolume boundingVolume = new BoundingVolume(childBoundingBox);
+        BoundingVolume boundingVolume = new BoundingVolume(childBoundingBox, true);
 
         String nodeCode = parentNode.getNodeCode();
         LevelOfDetail minLod = LevelOfDetail.getByLevel(minLevel);

--- a/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/Batched3DModelTiler.java
+++ b/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/Batched3DModelTiler.java
@@ -47,6 +47,11 @@ public class Batched3DModelTiler extends DefaultTiler implements Tiler {
         Node root = createRoot();
         root.setBoundingVolume(new BoundingVolume(globalBoundingBox, globalOptions.isCartesian()));
         root.setTransformMatrix(transformMatrix, globalOptions.isClassicTransformMatrix());
+        if (globalOptions.isCartesian()) {
+            Matrix4d rootTransformMatrix = new Matrix4d();
+            rootTransformMatrix.setTranslation(globalOptions.getTranslateOffset());
+            root.setTransform(rootTransformMatrix.get(new float[16]));
+        }
         root.setGeometricError(geometricError);
 
         try {

--- a/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/DefaultTiler.java
+++ b/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/DefaultTiler.java
@@ -59,8 +59,9 @@ public abstract class DefaultTiler {
 
     protected Matrix4d getTransformMatrix(GaiaBoundingBox cartographicBoundingBox) {
         Vector3d center = cartographicBoundingBox.getCenter();
-        double[] cartesian = GlobeUtils.geographicToCartesianWgs84(center.x, center.y, center.z);
-        return GlobeUtils.transformMatrixAtCartesianPointWgs84(cartesian[0], cartesian[1], cartesian[2]);
+        // double[] cartesian = GlobeUtils.geographicToCartesianWgs84(center.x, center.y, center.z);
+        // return GlobeUtils.transformMatrixAtCartesianPointWgs84(cartesian[0], cartesian[1], cartesian[2]);
+        return GlobeUtils.transformMatrixAtCartesianPointWgs84(center.x, center.y, center.z);
     }
 
     protected Asset createAsset() {

--- a/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/DefaultTiler.java
+++ b/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/DefaultTiler.java
@@ -58,10 +58,14 @@ public abstract class DefaultTiler {
     }
 
     protected Matrix4d getTransformMatrix(GaiaBoundingBox cartographicBoundingBox) {
+        GlobalOptions globalOptions = GlobalOptions.getInstance();
         Vector3d center = cartographicBoundingBox.getCenter();
-        // double[] cartesian = GlobeUtils.geographicToCartesianWgs84(center.x, center.y, center.z);
-        // return GlobeUtils.transformMatrixAtCartesianPointWgs84(cartesian[0], cartesian[1], cartesian[2]);
-        return GlobeUtils.transformMatrixAtCartesianPointWgs84(center.x, center.y, center.z);
+        if (globalOptions.isCartesian()) {
+            return GlobeUtils.transformMatrixAtCartesianPointWgs84(center.x, center.y, center.z);
+        } else {            
+            double[] cartesian = GlobeUtils.geographicToCartesianWgs84(center.x, center.y, center.z);
+            return GlobeUtils.transformMatrixAtCartesianPointWgs84(cartesian[0], cartesian[1], cartesian[2]);
+        }
     }
 
     protected Asset createAsset() {
@@ -81,9 +85,11 @@ public abstract class DefaultTiler {
     }
 
     protected Node createRoot() {
+        GlobalOptions globalOptions = GlobalOptions.getInstance();
         Node root = new Node();
         root.setParent(root);
         root.setNodeCode("R");
+        root.setCartesian(globalOptions.isCartesian());
         root.setRefine(Node.RefineType.REPLACE);
         root.setChildren(new ArrayList<>());
         return root;

--- a/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/Instanced3DModelTiler.java
+++ b/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/Instanced3DModelTiler.java
@@ -222,7 +222,7 @@ public class Instanced3DModelTiler extends DefaultTiler implements Tiler {
             rotateX90(transformMatrix);
         }
 
-        BoundingVolume boundingVolume = new BoundingVolume(childBoundingBox, true);
+        BoundingVolume boundingVolume = new BoundingVolume(childBoundingBox);
 
         String nodeCode = parentNode.getNodeCode();
         LevelOfDetail minLod = LevelOfDetail.getByLevel(minLevel);

--- a/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/Instanced3DModelTiler.java
+++ b/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/Instanced3DModelTiler.java
@@ -222,7 +222,7 @@ public class Instanced3DModelTiler extends DefaultTiler implements Tiler {
             rotateX90(transformMatrix);
         }
 
-        BoundingVolume boundingVolume = new BoundingVolume(childBoundingBox);
+        BoundingVolume boundingVolume = new BoundingVolume(childBoundingBox, true);
 
         String nodeCode = parentNode.getNodeCode();
         LevelOfDetail minLod = LevelOfDetail.getByLevel(minLevel);

--- a/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/tileset/node/BoundingVolume.java
+++ b/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/tileset/node/BoundingVolume.java
@@ -48,8 +48,8 @@ public class BoundingVolume implements Serializable {
         this(boundingBox, false);
     }
 
-    public BoundingVolume(GaiaBoundingBox boundingBox, boolean asbox) {
-        if (asbox) {
+    public BoundingVolume(GaiaBoundingBox boundingBox, boolean cartesian) {
+        if (cartesian) {
             // The first three elements define the x, y, and z values for the center of the box.
             // The next three elements (with indices 3, 4, and 5) define the x-axis direction and half-length.
             // The next three elements (indices 6, 7, and 8) define the y-axis direction and half-length.

--- a/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/tileset/node/Node.java
+++ b/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/tileset/node/Node.java
@@ -38,6 +38,8 @@ public class Node {
     @JsonIgnore
     private GaiaBoundingBox boundingBox;
     @JsonIgnore
+    private boolean cartesian;
+    @JsonIgnore
     private int depth;
 
     private BoundingVolume boundingVolume;
@@ -290,7 +292,7 @@ public class Node {
         child0.setDepth(this.getDepth() + 1);
         child0.setGeometricError(childGeometricError);
         GaiaBoundingBox child0BoundingBox = new GaiaBoundingBox(minLonDeg, minLatDeg, minAltitude, midLonDeg, midLatDeg, midAltitude, false);
-        child0.setBoundingVolume(new BoundingVolume(child0BoundingBox, true));
+        child0.setBoundingVolume(new BoundingVolume(child0BoundingBox, cartesian));
         child0.setNodeCode(parentNodeCode + "0");
 
         // 1. right - down - bottom
@@ -300,7 +302,7 @@ public class Node {
         child1.setDepth(this.getDepth() + 1);
         child1.setGeometricError(childGeometricError);
         GaiaBoundingBox child1BoundingBox = new GaiaBoundingBox(midLonDeg, minLatDeg, minAltitude, maxLonDeg, midLatDeg, midAltitude, false);
-        child1.setBoundingVolume(new BoundingVolume(child1BoundingBox, true));
+        child1.setBoundingVolume(new BoundingVolume(child1BoundingBox, cartesian));
         child1.setNodeCode(parentNodeCode + "1");
 
         // 2. right - up - bottom
@@ -310,7 +312,7 @@ public class Node {
         child2.setDepth(this.getDepth() + 1);
         child2.setGeometricError(childGeometricError);
         GaiaBoundingBox child2BoundingBox = new GaiaBoundingBox(midLonDeg, midLatDeg, minAltitude, maxLonDeg, maxLatDeg, midAltitude, false);
-        child2.setBoundingVolume(new BoundingVolume(child2BoundingBox, true));
+        child2.setBoundingVolume(new BoundingVolume(child2BoundingBox, cartesian));
         child2.setNodeCode(parentNodeCode + "2");
 
         // 3. left - up - bottom
@@ -320,7 +322,7 @@ public class Node {
         child3.setDepth(this.getDepth() + 1);
         child3.setGeometricError(childGeometricError);
         GaiaBoundingBox child3BoundingBox = new GaiaBoundingBox(minLonDeg, midLatDeg, minAltitude, midLonDeg, maxLatDeg, midAltitude, false);
-        child3.setBoundingVolume(new BoundingVolume(child3BoundingBox, true));
+        child3.setBoundingVolume(new BoundingVolume(child3BoundingBox, cartesian));
         child3.setNodeCode(parentNodeCode + "3");
 
         // 4. left - down - top
@@ -330,7 +332,7 @@ public class Node {
         child4.setDepth(this.getDepth() + 1);
         child4.setGeometricError(childGeometricError);
         GaiaBoundingBox child4BoundingBox = new GaiaBoundingBox(minLonDeg, minLatDeg, midAltitude, midLonDeg, midLatDeg, maxAltitude, false);
-        child4.setBoundingVolume(new BoundingVolume(child4BoundingBox, true));
+        child4.setBoundingVolume(new BoundingVolume(child4BoundingBox, cartesian));
         child4.setNodeCode(parentNodeCode + "4");
 
         // 5. right - down - top
@@ -340,7 +342,7 @@ public class Node {
         child5.setDepth(this.getDepth() + 1);
         child5.setGeometricError(childGeometricError);
         GaiaBoundingBox child5BoundingBox = new GaiaBoundingBox(midLonDeg, minLatDeg, midAltitude, maxLonDeg, midLatDeg, maxAltitude, false);
-        child5.setBoundingVolume(new BoundingVolume(child5BoundingBox, true));
+        child5.setBoundingVolume(new BoundingVolume(child5BoundingBox, cartesian));
         child5.setNodeCode(parentNodeCode + "5");
 
         // 6. right - up - top
@@ -350,7 +352,7 @@ public class Node {
         child6.setDepth(this.getDepth() + 1);
         child6.setGeometricError(childGeometricError);
         GaiaBoundingBox child6BoundingBox = new GaiaBoundingBox(midLonDeg, midLatDeg, midAltitude, maxLonDeg, maxLatDeg, maxAltitude, false);
-        child6.setBoundingVolume(new BoundingVolume(child6BoundingBox, true));
+        child6.setBoundingVolume(new BoundingVolume(child6BoundingBox, cartesian));
         child6.setNodeCode(parentNodeCode + "6");
 
         // 7. left - up - top
@@ -360,7 +362,7 @@ public class Node {
         child7.setDepth(this.getDepth() + 1);
         child7.setGeometricError(childGeometricError);
         GaiaBoundingBox child7BoundingBox = new GaiaBoundingBox(minLonDeg, midLatDeg, midAltitude, midLonDeg, maxLatDeg, maxAltitude, false);
-        child7.setBoundingVolume(new BoundingVolume(child7BoundingBox, true));
+        child7.setBoundingVolume(new BoundingVolume(child7BoundingBox, cartesian));
         child7.setNodeCode(parentNodeCode + "7");
     }
 

--- a/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/tileset/node/Node.java
+++ b/tiler/src/main/java/com/gaia3d/process/tileprocess/tile/tileset/node/Node.java
@@ -290,7 +290,7 @@ public class Node {
         child0.setDepth(this.getDepth() + 1);
         child0.setGeometricError(childGeometricError);
         GaiaBoundingBox child0BoundingBox = new GaiaBoundingBox(minLonDeg, minLatDeg, minAltitude, midLonDeg, midLatDeg, midAltitude, false);
-        child0.setBoundingVolume(new BoundingVolume(child0BoundingBox));
+        child0.setBoundingVolume(new BoundingVolume(child0BoundingBox, true));
         child0.setNodeCode(parentNodeCode + "0");
 
         // 1. right - down - bottom
@@ -300,7 +300,7 @@ public class Node {
         child1.setDepth(this.getDepth() + 1);
         child1.setGeometricError(childGeometricError);
         GaiaBoundingBox child1BoundingBox = new GaiaBoundingBox(midLonDeg, minLatDeg, minAltitude, maxLonDeg, midLatDeg, midAltitude, false);
-        child1.setBoundingVolume(new BoundingVolume(child1BoundingBox));
+        child1.setBoundingVolume(new BoundingVolume(child1BoundingBox, true));
         child1.setNodeCode(parentNodeCode + "1");
 
         // 2. right - up - bottom
@@ -310,7 +310,7 @@ public class Node {
         child2.setDepth(this.getDepth() + 1);
         child2.setGeometricError(childGeometricError);
         GaiaBoundingBox child2BoundingBox = new GaiaBoundingBox(midLonDeg, midLatDeg, minAltitude, maxLonDeg, maxLatDeg, midAltitude, false);
-        child2.setBoundingVolume(new BoundingVolume(child2BoundingBox));
+        child2.setBoundingVolume(new BoundingVolume(child2BoundingBox, true));
         child2.setNodeCode(parentNodeCode + "2");
 
         // 3. left - up - bottom
@@ -320,7 +320,7 @@ public class Node {
         child3.setDepth(this.getDepth() + 1);
         child3.setGeometricError(childGeometricError);
         GaiaBoundingBox child3BoundingBox = new GaiaBoundingBox(minLonDeg, midLatDeg, minAltitude, midLonDeg, maxLatDeg, midAltitude, false);
-        child3.setBoundingVolume(new BoundingVolume(child3BoundingBox));
+        child3.setBoundingVolume(new BoundingVolume(child3BoundingBox, true));
         child3.setNodeCode(parentNodeCode + "3");
 
         // 4. left - down - top
@@ -330,7 +330,7 @@ public class Node {
         child4.setDepth(this.getDepth() + 1);
         child4.setGeometricError(childGeometricError);
         GaiaBoundingBox child4BoundingBox = new GaiaBoundingBox(minLonDeg, minLatDeg, midAltitude, midLonDeg, midLatDeg, maxAltitude, false);
-        child4.setBoundingVolume(new BoundingVolume(child4BoundingBox));
+        child4.setBoundingVolume(new BoundingVolume(child4BoundingBox, true));
         child4.setNodeCode(parentNodeCode + "4");
 
         // 5. right - down - top
@@ -340,7 +340,7 @@ public class Node {
         child5.setDepth(this.getDepth() + 1);
         child5.setGeometricError(childGeometricError);
         GaiaBoundingBox child5BoundingBox = new GaiaBoundingBox(midLonDeg, minLatDeg, midAltitude, maxLonDeg, midLatDeg, maxAltitude, false);
-        child5.setBoundingVolume(new BoundingVolume(child5BoundingBox));
+        child5.setBoundingVolume(new BoundingVolume(child5BoundingBox, true));
         child5.setNodeCode(parentNodeCode + "5");
 
         // 6. right - up - top
@@ -350,7 +350,7 @@ public class Node {
         child6.setDepth(this.getDepth() + 1);
         child6.setGeometricError(childGeometricError);
         GaiaBoundingBox child6BoundingBox = new GaiaBoundingBox(midLonDeg, midLatDeg, midAltitude, maxLonDeg, maxLatDeg, maxAltitude, false);
-        child6.setBoundingVolume(new BoundingVolume(child6BoundingBox));
+        child6.setBoundingVolume(new BoundingVolume(child6BoundingBox, true));
         child6.setNodeCode(parentNodeCode + "6");
 
         // 7. left - up - top
@@ -360,7 +360,7 @@ public class Node {
         child7.setDepth(this.getDepth() + 1);
         child7.setGeometricError(childGeometricError);
         GaiaBoundingBox child7BoundingBox = new GaiaBoundingBox(minLonDeg, midLatDeg, midAltitude, midLonDeg, maxLatDeg, maxAltitude, false);
-        child7.setBoundingVolume(new BoundingVolume(child7BoundingBox));
+        child7.setBoundingVolume(new BoundingVolume(child7BoundingBox, true));
         child7.setNodeCode(parentNodeCode + "7");
     }
 


### PR DESCRIPTION
This PR is an experimental implementation for 3D tiles output with cartesic coordinates.

It's not complete and maybe not the best way to do it (I'm a Rust & Python programmer, sorry), but would be great to get feedback, whether this would fit into mago-3d-tiler.

With the new `--cartesic` flag, the following changes apply (for Batched3DModelTiler at least):
* Transform matrices for nodes are *not* transformed to geographic coordinates
* Bounding volumes are defined as box instead of a region
* Offsets (`--xOffset`,...) are applied as a translation of the root node only