### PR TITLE
feat: preserve glTF up-axis and filter invalid terrain heights

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 subprojects {
     group "com.gaia3d"
-    version "1.16.0"
+    version "1.16.2"
     apply plugin: 'java'
     project.ext.lwjglVersion = "3.3.6"
 

--- a/mago-tiler/src/main/java/com/gaia3d/process/preprocess/GaiaZUpTransformer.java
+++ b/mago-tiler/src/main/java/com/gaia3d/process/preprocess/GaiaZUpTransformer.java
@@ -3,6 +3,7 @@ package com.gaia3d.process.preprocess;
 import com.gaia3d.basic.geometry.modifier.transform.UpAxisTransformer;
 import com.gaia3d.basic.model.GaiaNode;
 import com.gaia3d.basic.model.GaiaScene;
+import com.gaia3d.basic.types.FormatType;
 import com.gaia3d.command.mago.GlobalOptions;
 import com.gaia3d.process.tileprocess.tile.TileInfo;
 import lombok.NoArgsConstructor;
@@ -74,6 +75,10 @@ public class GaiaZUpTransformer implements PreProcess {
                 return tileInfo;
             }
 
+            if (hasExplicitUpAxis(scene)) {
+                return tileInfo;
+            }
+
             Matrix3d rotationMatrix = createNormalMatrix3d(scene);
             boolean isZUp = isZUpAxis(rotationMatrix);
             boolean isYUp = isYUpAxis(rotationMatrix);
@@ -109,6 +114,21 @@ public class GaiaZUpTransformer implements PreProcess {
 
         tileInfo.updateSceneInfo();
         return tileInfo;
+    }
+
+    private boolean hasExplicitUpAxis(GaiaScene scene) {
+        if (scene.getOriginalPath() == null || scene.getOriginalPath().getFileName() == null) {
+            return false;
+        }
+
+        String fileName = scene.getOriginalPath().getFileName().toString();
+        int extensionSeparator = fileName.lastIndexOf('.');
+        if (extensionSeparator < 0 || extensionSeparator == fileName.length() - 1) {
+            return false;
+        }
+
+        FormatType formatType = FormatType.fromExtension(fileName.substring(extensionSeparator + 1));
+        return formatType == FormatType.GLB || formatType == FormatType.GLTF;
     }
 
     private Matrix3d createNormalMatrix3d(GaiaScene scene) {

--- a/mago-tiler/src/main/java/com/gaia3d/terrain/GeoTiffTerrainHeightProvider.java
+++ b/mago-tiler/src/main/java/com/gaia3d/terrain/GeoTiffTerrainHeightProvider.java
@@ -18,6 +18,7 @@ import java.util.OptionalDouble;
 
 @Slf4j
 public class GeoTiffTerrainHeightProvider implements TerrainHeightProvider {
+    private static final double MAXIMUM_ABSOLUTE_TERRAIN_HEIGHT = 100_000.0;
     private final List<CoverageSampler> samplers;
 
     public GeoTiffTerrainHeightProvider(List<GridCoverage2D> coverages) {
@@ -34,11 +35,38 @@ public class GeoTiffTerrainHeightProvider implements TerrainHeightProvider {
                 MathTransform worldToGridCenter = coverage.getGridGeometry()
                         .getGridToCRS2D(PixelOrientation.CENTER)
                         .inverse();
-                samplers.add(new CoverageSampler(coverage, fromWgs84, worldToGridCenter));
+                samplers.add(new CoverageSampler(
+                        coverage,
+                        fromWgs84,
+                        worldToGridCenter,
+                        getNoDataValues(coverage)));
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to initialize GeoTIFF terrain sampler", e);
             }
         }
+    }
+
+    private double[] getNoDataValues(GridCoverage2D coverage) {
+        try {
+            double[] noDataValues = coverage.getSampleDimension(0).getNoDataValues();
+            return noDataValues == null ? new double[0] : noDataValues.clone();
+        } catch (IllegalStateException e) {
+            log.debug("GeoTIFF terrain does not provide readable NoData metadata");
+            return new double[0];
+        }
+    }
+
+    static boolean isValidTerrainHeight(double height, double[] noDataValues) {
+        if (!Double.isFinite(height) || Math.abs(height) > MAXIMUM_ABSOLUTE_TERRAIN_HEIGHT) {
+            return false;
+        }
+        for (double noDataValue : noDataValues) {
+            if ((Double.isNaN(noDataValue) && Double.isNaN(height))
+                    || Double.compare(height, noDataValue) == 0) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
@@ -65,7 +93,8 @@ public class GeoTiffTerrainHeightProvider implements TerrainHeightProvider {
     private record CoverageSampler(
             GridCoverage2D coverage,
             MathTransform fromWgs84,
-            MathTransform worldToGridCenter) {
+            MathTransform worldToGridCenter,
+            double[] noDataValues) {
 
         private static int clamp(int value, int minimum, int maximum) {
             return Math.max(minimum, Math.min(maximum, value));
@@ -102,14 +131,19 @@ public class GeoTiffTerrainHeightProvider implements TerrainHeightProvider {
             double topRight = raster.getSampleDouble(x1, y0, 0);
             double bottomLeft = raster.getSampleDouble(x0, y1, 0);
             double bottomRight = raster.getSampleDouble(x1, y1, 0);
-            if (!Double.isFinite(topLeft) || !Double.isFinite(topRight)
-                    || !Double.isFinite(bottomLeft) || !Double.isFinite(bottomRight)) {
+            if (!isValidTerrainHeight(topLeft, noDataValues)
+                    || !isValidTerrainHeight(topRight, noDataValues)
+                    || !isValidTerrainHeight(bottomLeft, noDataValues)
+                    || !isValidTerrainHeight(bottomRight, noDataValues)) {
                 return OptionalDouble.empty();
             }
 
             double top = topLeft * (1.0 - fractionX) + topRight * fractionX;
             double bottom = bottomLeft * (1.0 - fractionX) + bottomRight * fractionX;
-            return OptionalDouble.of(top * (1.0 - fractionY) + bottom * fractionY);
+            double height = top * (1.0 - fractionY) + bottom * fractionY;
+            return isValidTerrainHeight(height, noDataValues)
+                    ? OptionalDouble.of(height)
+                    : OptionalDouble.empty();
         }
     }
 }

--- a/mago-tiler/src/test/java/com/gaia3d/local/experimental/ForestExperimentalTest.java
+++ b/mago-tiler/src/test/java/com/gaia3d/local/experimental/ForestExperimentalTest.java
@@ -377,6 +377,42 @@ public class ForestExperimentalTest {
     }
 
     @Test
+    void garisanChimVersion3Test() {
+        String path = "garisan/Chim";
+        String[] args = new String[]{
+                "-i", MagoTestConfig.getSsdInputPath(path).getAbsolutePath(),
+                "-o", MagoTestConfig.getOutputPath(path).getAbsolutePath() + "-other-dem-temp",
+                "-c", "5187",
+                "-ot", "i3dm",
+                "--refineAdd",
+                "--scaleColumn", "TreeHeight",
+                "--tilesVersion", "1.0",
+                "-instance", "D:\\user\\znkim\\Downloads\\Export_GLB\\Triangles_200.glb",
+                "-terrain", "D:\\user\\znkim\\Downloads\\merged_dem_5186.tif",
+                "-maxLod", "4",
+        };
+        MagoTestConfig.execute(args);
+    }
+
+    @Test
+    void garisanChimVersion2Test() {
+        String path = "garisan/Chim";
+        String[] args = new String[]{
+                "-i", MagoTestConfig.getSsdInputPath(path).getAbsolutePath(),
+                "-o", MagoTestConfig.getOutputPath(path).getAbsolutePath() + "-temp",
+                "-c", "5187",
+                "-ot", "i3dm",
+                "--refineAdd",
+                "--scaleColumn", "TreeHeight",
+                "--tilesVersion", "1.0",
+                "-instance", "D:\\user\\znkim\\Downloads\\chim-sample-low-test.glb",
+                "-terrain", MagoTestConfig.getTerrainPath("korea-05-cog-dem-4326.tif").getAbsolutePath(),
+                "-maxLod", "4",
+        };
+        MagoTestConfig.execute(args);
+    }
+
+    @Test
     void garisanChim() {
         String path = "garisan/Chim";
         String[] args = new String[]{

--- a/mago-tiler/src/test/java/com/gaia3d/process/preprocess/GaiaZUpTransformerTest.java
+++ b/mago-tiler/src/test/java/com/gaia3d/process/preprocess/GaiaZUpTransformerTest.java
@@ -1,0 +1,49 @@
+package com.gaia3d.process.preprocess;
+
+import com.gaia3d.basic.model.GaiaNode;
+import com.gaia3d.basic.model.GaiaScene;
+import com.gaia3d.process.tileprocess.tile.TileInfo;
+import org.joml.Matrix4d;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("default")
+class GaiaZUpTransformerTest {
+
+    @Test
+    void preservesGltfNodeTransformBecauseTheFormatDefinesYUp() {
+        GaiaScene scene = sceneWithXRotation(90.0, "model.glb");
+        Matrix4d originalTransform = new Matrix4d(scene.getNodes().getFirst().getTransformMatrix());
+        TileInfo tileInfo = TileInfo.builder().scene(scene).build();
+
+        new GaiaZUpTransformer().run(tileInfo);
+
+        assertEquals(originalTransform, scene.getNodes().getFirst().getTransformMatrix());
+    }
+
+    @Test
+    void stillAutoDetectsFormatsWithoutAnExplicitUpAxis() {
+        GaiaScene scene = sceneWithXRotation(90.0, "model.obj");
+        Matrix4d expectedTransform = new Matrix4d(scene.getNodes().getFirst().getTransformMatrix())
+                .rotateX(Math.toRadians(90.0));
+        TileInfo tileInfo = TileInfo.builder().scene(scene).build();
+
+        new GaiaZUpTransformer().run(tileInfo);
+
+        assertTrue(expectedTransform.equals(scene.getNodes().getFirst().getTransformMatrix(), 1e-12));
+    }
+
+    private GaiaScene sceneWithXRotation(double degrees, String fileName) {
+        GaiaScene scene = new GaiaScene();
+        GaiaNode rootNode = new GaiaNode();
+        rootNode.setTransformMatrix(new Matrix4d().rotateX(Math.toRadians(degrees)));
+        scene.getNodes().add(rootNode);
+        scene.setOriginalPath(Path.of(fileName));
+        return scene;
+    }
+}

--- a/mago-tiler/src/test/java/com/gaia3d/terrain/GeoTiffTerrainHeightProviderTest.java
+++ b/mago-tiler/src/test/java/com/gaia3d/terrain/GeoTiffTerrainHeightProviderTest.java
@@ -1,0 +1,32 @@
+package com.gaia3d.terrain;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("default")
+class GeoTiffTerrainHeightProviderTest {
+
+    @Test
+    void rejectsDeclaredNoDataAndNonFiniteValues() {
+        double[] noDataValues = {-9999.0};
+
+        assertFalse(GeoTiffTerrainHeightProvider.isValidTerrainHeight(-9999.0, noDataValues));
+        assertFalse(GeoTiffTerrainHeightProvider.isValidTerrainHeight(Double.NaN, noDataValues));
+        assertFalse(GeoTiffTerrainHeightProvider.isValidTerrainHeight(Double.POSITIVE_INFINITY, noDataValues));
+    }
+
+    @Test
+    void rejectsExtremeSentinelValuesWithoutNoDataMetadata() {
+        assertFalse(GeoTiffTerrainHeightProvider.isValidTerrainHeight(-3.017897893241e38, new double[0]));
+        assertFalse(GeoTiffTerrainHeightProvider.isValidTerrainHeight(3.017897893241e38, new double[0]));
+    }
+
+    @Test
+    void acceptsRealisticTerrainHeights() {
+        assertTrue(GeoTiffTerrainHeightProvider.isValidTerrainHeight(-430.5, new double[0]));
+        assertTrue(GeoTiffTerrainHeightProvider.isValidTerrainHeight(8848.86, new double[0]));
+    }
+}


### PR DESCRIPTION
- skip automatic up-axis detection for GLB and glTF instance models
- preserve model node transforms while allowing explicit X-axis rotation
- filter GeoTIFF NoData, non-finite, and extreme terrain height values
- prevent invalid pixels from contaminating bilinear terrain interpolation
- add regression tests for glTF transforms and terrain height validation